### PR TITLE
Fix bug for disabled field in NestedForm

### DIFF
--- a/modules/backend/formwidgets/NestedForm.php
+++ b/modules/backend/formwidgets/NestedForm.php
@@ -42,9 +42,6 @@ class NestedForm extends FormWidgetBase
             'usePanelStyles',
         ]);
 
-        if ($this->formField->disabled) {
-            $this->previewMode = true;
-        }
 
         $config = $this->makeConfig($this->form);
         $config->model = $this->model;
@@ -52,6 +49,12 @@ class NestedForm extends FormWidgetBase
         $config->alias = $this->alias . $this->defaultAlias;
         $config->arrayName = $this->getFieldName();
         $config->isNested = true;
+
+        if ($this->formField->disabled) {
+            foreach ($config->fields as &$field) {
+                $field["disabled"] = true;
+            };
+        }
 
         if (object_get($this->getParentForm()->config, 'enableDefaults') === true) {
             $config->enableDefaults = true;


### PR DESCRIPTION
## Related Issue
#3 

## Updates 
- Iterate over the fields to disable nested form to get correct disabled Field instead of disabling from NestedForm Level.

## Test

I tested with this fields.yaml file.

```
tabs:
    fields:
        updated_at:
            tab: Ontwerp
            label: Updated at
            type: datepicker
            disabled: true

        configuration:
            tab: Ontwerp
            type: nestedform
            usePanelStyles: false
            disabled: true
            trigger:
                action: hide
                field: approved_status
                condition: value[canceled]
            form:
                fields:

                    created_at:
                        label: Original created at
                        type: datepicker
```

<img width="1127" height="623" alt="Screenshot from 2026-02-24 10-08-40" src="https://github.com/user-attachments/assets/e6d51e2b-4c4d-48c4-997d-36c440e69fd9" />
