### PR TITLE
Fix "NestedForm Inherits Values from Parent Form" Bug

### DIFF
--- a/modules/backend/formwidgets/NestedForm.php
+++ b/modules/backend/formwidgets/NestedForm.php
@@ -2,6 +2,7 @@
 
 use Backend\Classes\FormWidgetBase;
 use Backend\Widgets\Form;
+use Winter\Storm\Database\Model;
 
 /**
  * Nested Form
@@ -46,9 +47,23 @@ class NestedForm extends FormWidgetBase
             $this->previewMode = true;
         }
 
+        $nestedData = $this->getLoadValue();
+        
+        $dummyModel = new class extends Model {
+            public function __get($key) {
+                return null;
+            }
+            public function __isset($key) {
+                return false;
+            }
+            public function exists() {
+                return false;
+            }
+        };
+        
         $config = $this->makeConfig($this->form);
-        $config->model = $this->model;
-        $config->data = $this->getLoadValue();
+        $config->model = $dummyModel;
+        $config->data = $nestedData ?: [];
         $config->alias = $this->alias . $this->defaultAlias;
         $config->arrayName = $this->getFieldName();
         $config->isNested = true;


### PR DESCRIPTION
## Related Issue
#4 

## Updates 
Create a dummy model that prevents nested form fields from inheriting
values from the parent form's model. This is necessary because:

1. Form widgets use getLoadValue() which falls back to $this->model when data is falsy (FormWidgetBase line 150)
2. When a nested form field (e.g., "name") doesn't exist in the nested data array, it would otherwise check the parent model and inherit the parent's "name" value
3. The Form widget requires a model instance, so we provide a dummy one that always returns null for attributes


## Screenshot
The repeater form doesn't show the page name as shown in the issue.
<img width="1167" height="658" alt="Screenshot from 2026-03-01 13-11-32" src="https://github.com/user-attachments/assets/3e5d67b8-ebd9-4679-b25d-fb14ede655fd" />
